### PR TITLE
Fix: default value for optional `_unpack` argument

### DIFF
--- a/scripts/TestCase/TestCase.gml
+++ b/scripts/TestCase/TestCase.gml
@@ -3,7 +3,7 @@
  * @constructor TestCase
  * @param {string} _name - Name of case
  * @param {function} _func - Method containing assertion method
- * @param [struct] _unpack - Struct for crispyStructUnpack
+ * @param [struct] _unpack=undefined - Struct for crispyStructUnpack
  */
 function TestCase(_name, _func, _unpack = undefined) : BaseTestClass(_name) constructor {
 

--- a/scripts/TestCase/TestCase.gml
+++ b/scripts/TestCase/TestCase.gml
@@ -5,7 +5,7 @@
  * @param {function} _func - Method containing assertion method
  * @param [struct] _unpack - Struct for crispyStructUnpack
  */
-function TestCase(_name, _func, _unpack) : BaseTestClass(_name) constructor {
+function TestCase(_name, _func, _unpack = undefined) : BaseTestClass(_name) constructor {
 
 	class = instanceof(self);
 	parent = undefined;

--- a/scripts/TestRunner/TestRunner.gml
+++ b/scripts/TestRunner/TestRunner.gml
@@ -4,7 +4,7 @@
  * @param {string} _name - Name of runner
  * @param [struct] _unpack - Struct for crispyStructUnpack
  */
-function TestRunner(_name, _unpack) : BaseTestClass(_name) constructor {
+function TestRunner(_name, _unpack = undefined) : BaseTestClass(_name) constructor {
 
 	start_time = 0;
 	stop_time = 0;

--- a/scripts/TestRunner/TestRunner.gml
+++ b/scripts/TestRunner/TestRunner.gml
@@ -2,7 +2,7 @@
  * Runner to hold test suites and iterates through each TestSuite, running its tests
  * @constructor TestRunner
  * @param {string} _name - Name of runner
- * @param [struct] _unpack - Struct for crispyStructUnpack
+ * @param [struct] _unpack=undefined - Struct for crispyStructUnpack
  */
 function TestRunner(_name, _unpack = undefined) : BaseTestClass(_name) constructor {
 

--- a/scripts/TestSuite/TestSuite.gml
+++ b/scripts/TestSuite/TestSuite.gml
@@ -4,7 +4,7 @@
  * @param {string} _name - Name of suite
  * @param [struct] _unpack - Struct for crispyStructUnpack
  */
-function TestSuite(_name, _unpack) : BaseTestClass(_name) constructor {
+function TestSuite(_name, _unpack = undefined) : BaseTestClass(_name) constructor {
 
 	parent = undefined;
 	tests = [];

--- a/scripts/TestSuite/TestSuite.gml
+++ b/scripts/TestSuite/TestSuite.gml
@@ -2,7 +2,7 @@
  * Testing suite that holds tests
  * @constructor TestSuite
  * @param {string} _name - Name of suite
- * @param [struct] _unpack - Struct for crispyStructUnpack
+ * @param [struct] _unpack=undefined - Struct for crispyStructUnpack
  */
 function TestSuite(_name, _unpack = undefined) : BaseTestClass(_name) constructor {
 


### PR DESCRIPTION
Hello!

I made a small fix to get rid of the annoying GameMaker Studio warning about the number of arguments when creating classes with tests. Now argument `_struct` of `TestCase`, `TestSuite` and `TestRunner` is truly optional.

Functionally, the code has not changed.

Thanks in advance.