### PR TITLE
Fix bool assert conditional statements

### DIFF
--- a/scripts/TestCase/TestCase.gml
+++ b/scripts/TestCase/TestCase.gml
@@ -147,7 +147,7 @@ function TestCase(_name, _func, _unpack=undefined) : BaseTestClass(_name) constr
 			}));
 			return;
 		}
-		if _expr == true {
+		if _expr {
 			addLog(new CrispyLog(self, {
 				pass: true,
 			}));
@@ -186,7 +186,7 @@ function TestCase(_name, _func, _unpack=undefined) : BaseTestClass(_name) constr
 			}));
 			return;
 		}
-		if _expr == false {
+		if !_expr {
 			addLog(new CrispyLog(self, {
 				pass: true,
 			}));


### PR DESCRIPTION
Fix boolean assertions by checking for truthy or falsy rather than equal to true or false